### PR TITLE
Swifter syntax, changed spacing between buttons, fixed typo in property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ extension ViewController: PasswordInputCompleteProtocol {
 
 ``` swift
 self.passwordContainerView.tintColor = UIColor.color(.TextColor)
-self.passwordContainerView.hightlightedColor = UIColor.color(.Blue)
+self.passwordContainerView.highlightedColor = UIColor.color(.Blue)
 ```
 
 #### 4. Visual Effect.

--- a/SmileLock-Example/SmileLock-Example/PasswordLoginViewController.swift
+++ b/SmileLock-Example/SmileLock-Example/PasswordLoginViewController.swift
@@ -39,7 +39,7 @@ private extension PasswordLoginViewController {
         NSLayoutConstraint.addEqualConstraintsFromSubView(self.passwordContainerView, toSuperView: self.baseView)
         self.passwordContainerView.delegate = self
         self.passwordContainerView.tintColor = UIColor.color(.TextColor)
-        self.passwordContainerView.hightlightedColor = UIColor.color(.Blue)
+        self.passwordContainerView.highlightedColor = UIColor.color(.Blue)
     }
 }
 

--- a/SmileLock/Assets/PasswordContainerView.xib
+++ b/SmileLock/Assets/PasswordContainerView.xib
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="16A239j" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
@@ -26,25 +26,25 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="jjW-ce-0kS">
                             <rect key="frame" x="0.0" y="41" width="288" height="370"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="uVh-VM-IQf">
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="uVh-VM-IQf">
                                     <rect key="frame" x="0.0" y="0.0" width="288" height="85"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mNO-I8-8HR" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="96" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="1"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R7E-OV-zzd" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="101" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="96" y="0.0" width="96" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="2"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EWl-Jj-Mvi" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="202" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="192" y="0.0" width="96" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="3"/>
@@ -52,25 +52,25 @@
                                         </view>
                                     </subviews>
                                 </stackView>
-                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="O9w-0G-0IG">
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="O9w-0G-0IG">
                                     <rect key="frame" x="0.0" y="95" width="288" height="85"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t6f-Qj-936" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="96" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="4"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LoJ-Bd-MiK" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="101" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="96" y="0.0" width="96" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="5"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5R9-ep-8IT" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="202" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="192" y="0.0" width="96" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="6"/>
@@ -78,25 +78,25 @@
                                         </view>
                                     </subviews>
                                 </stackView>
-                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="44G-t4-h3e">
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="44G-t4-h3e">
                                     <rect key="frame" x="0.0" y="190" width="288" height="85"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eRG-m3-KYK" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="96" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="7"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nUG-Ev-7sV" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="101" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="96" y="0.0" width="96" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="8"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4fx-v7-wSg" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="202" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="192" y="0.0" width="96" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="9"/>
@@ -104,21 +104,21 @@
                                         </view>
                                     </subviews>
                                 </stackView>
-                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Rfs-SF-Ii0">
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Rfs-SF-Ii0">
                                     <rect key="frame" x="0.0" y="285" width="288" height="85"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZHH-fS-8to">
-                                            <rect key="frame" x="0.0" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="96" height="85"/>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ruX-2t-uDv" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="101" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="96" y="0.0" width="96" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="0"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="abs-RL-KN4">
-                                            <rect key="frame" x="202" y="0.0" width="86" height="85"/>
+                                            <rect key="frame" x="192" y="0.0" width="96" height="85"/>
                                             <fontDescription key="fontDescription" type="system" weight="light" pointSize="22"/>
                                             <state key="normal" title="Delete">
                                                 <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
@@ -159,6 +159,7 @@
                 <outletCollection property="passwordInputViews" destination="4fx-v7-wSg" collectionClass="NSMutableArray" id="tuq-os-z0g"/>
                 <outletCollection property="passwordInputViews" destination="ruX-2t-uDv" collectionClass="NSMutableArray" id="6SR-U3-JMn"/>
             </connections>
+            <point key="canvasLocation" x="290" y="315.5"/>
         </view>
     </objects>
 </document>

--- a/SmileLock/Classes/PasswordContainerView.swift
+++ b/SmileLock/Classes/PasswordContainerView.swift
@@ -23,22 +23,22 @@ public class PasswordContainerView: UIView {
     
     private var inputString: String = "" {
         didSet {
-            self.passwordDotView.inputDotCount = self.inputString.characters.count
-            self.checkInputComplete()
+            passwordDotView.inputDotCount = inputString.characters.count
+            checkInputComplete()
         }
     }
     
     public var isVibrancyEffect = false {
         didSet {
-            self.configureVibrancyEffect()
+            configureVibrancyEffect()
         }
     }
     
     public override var tintColor: UIColor! {
         didSet {
             if isVibrancyEffect { return }
-            self.deleteButton.setTitleColor(tintColor, forState: .Normal)
-            self.passwordDotView.strokeColor = tintColor
+            deleteButton.setTitleColor(tintColor, forState: .Normal)
+            passwordDotView.strokeColor = tintColor
             passwordInputViews.forEach {
                 $0.textColor = tintColor
                 $0.borderColor = tintColor
@@ -46,12 +46,12 @@ public class PasswordContainerView: UIView {
         }
     }
     
-    public var hightlightedColor: UIColor! {
+    public var highlightedColor: UIColor! {
         didSet {
             if isVibrancyEffect { return }
-            self.passwordDotView.fillColor = hightlightedColor
+            passwordDotView.fillColor = highlightedColor
             passwordInputViews.forEach {
-                $0.highlightBackgroundColor = hightlightedColor
+                $0.highlightBackgroundColor = highlightedColor
             }
         }
     }
@@ -67,34 +67,34 @@ public class PasswordContainerView: UIView {
     
     public override func awakeFromNib() {
         super.awakeFromNib()
-        self.backgroundColor = UIColor.clearColor()
+        backgroundColor = UIColor.clearColor()
         passwordInputViews.forEach {
             $0.delegate = self
         }
-        self.deleteButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        self.deleteButton.titleLabel?.minimumScaleFactor = 0.5
+        deleteButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        deleteButton.titleLabel?.minimumScaleFactor = 0.5
     }
     
     //MARK: Input Wrong
     public func wrongPassword() {
-        self.passwordDotView.shakeAnimationWithCompletion {
+        passwordDotView.shakeAnimationWithCompletion {
             self.inputString = ""
         }
     }
     
     //MARK: IBAction
     @IBAction func deleteInputString(sender: AnyObject) {
-        guard self.inputString.characters.count > 0 && !self.passwordDotView.isFull  else {
+        guard inputString.characters.count > 0 && !passwordDotView.isFull  else {
             return
         }
-        self.inputString = String(self.inputString.characters.dropLast())
+        inputString = String(inputString.characters.dropLast())
     }
 }
 
 private extension PasswordContainerView {
     func checkInputComplete() {
-        if self.inputString.characters.count == self.passwordDotView.totalDotCount {
-            self.delegate?.passwordInputComplete(self, input: self.inputString)
+        if inputString.characters.count == passwordDotView.totalDotCount {
+            delegate?.passwordInputComplete(self, input: inputString)
         }
     }
     func configureVibrancyEffect() {
@@ -114,7 +114,7 @@ private extension PasswordContainerView {
         var textColor: UIColor!
         var highlightTextColor: UIColor!
         
-        if self.isVibrancyEffect {
+        if isVibrancyEffect {
             //delete button
             titleColor = whiteColor
             //dot view
@@ -128,22 +128,22 @@ private extension PasswordContainerView {
             highlightTextColor = whiteColor
         } else {
             //delete button
-            titleColor = self.tintColor
+            titleColor = tintColor
             //dot view
-            strokeColor = self.tintColor
-            fillColor = self.hightlightedColor
+            strokeColor = tintColor
+            fillColor = highlightedColor
             //input view
             circleBackgroundColor = whiteColor
-            highlightBackgroundColor = self.hightlightedColor
-            borderColor = self.tintColor
-            textColor = self.tintColor
-            highlightTextColor = self.hightlightedColor
+            highlightBackgroundColor = highlightedColor
+            borderColor = tintColor
+            textColor = tintColor
+            highlightTextColor = highlightedColor
         }
         
-        self.deleteButton.setTitleColor(titleColor, forState: .Normal)
-        self.passwordDotView.strokeColor = strokeColor
-        self.passwordDotView.fillColor = fillColor
-        self.passwordInputViews.forEach { passwordInputView in
+        deleteButton.setTitleColor(titleColor, forState: .Normal)
+        passwordDotView.strokeColor = strokeColor
+        passwordDotView.fillColor = fillColor
+        passwordInputViews.forEach { passwordInputView in
             passwordInputView.circleBackgroundColor = circleBackgroundColor
             passwordInputView.borderColor = borderColor
             passwordInputView.textColor = textColor
@@ -161,6 +161,6 @@ extension PasswordContainerView: PasswordInputViewTappedProtocol {
         guard inputString.characters.count < passwordDotView.totalDotCount else {
             return
         }
-        self.inputString += tappedString
+        inputString += tappedString
     }
 }

--- a/SmileLock/Classes/PasswordDotView.swift
+++ b/SmileLock/Classes/PasswordDotView.swift
@@ -14,28 +14,28 @@ public class PasswordDotView: UIView {
     @IBInspectable
     public var inputDotCount: Int = 0 {
         didSet {
-            self.setNeedsDisplay()
+            setNeedsDisplay()
         }
     }
     
     @IBInspectable
     public var totalDotCount: Int = 6 {
         didSet {
-            self.setNeedsDisplay()
+            setNeedsDisplay()
         }
     }
     
     @IBInspectable
     public var strokeColor: UIColor = UIColor.darkGrayColor() {
         didSet {
-            self.setNeedsDisplay()
+            setNeedsDisplay()
         }
     }
     
     @IBInspectable
     public var fillColor: UIColor = UIColor.redColor() {
         didSet {
-            self.setNeedsDisplay()
+            setNeedsDisplay()
         }
     }
 
@@ -43,22 +43,19 @@ public class PasswordDotView: UIView {
     private let spacingRatio: CGFloat = 2
     private let borderWidthRatio: CGFloat = 1 / 5
     
-    private var _isFull = false
-    public  var isFull: Bool {
-        return _isFull
-    }
+    private(set) public var isFull = false
     
     //MARK: Draw
     public override func drawRect(rect: CGRect) {
         super.drawRect(rect)
-        self._isFull = (self.inputDotCount == self.totalDotCount)
-        self.strokeColor.setStroke()
-        self.fillColor.setFill()
-        let isOdd = (self.totalDotCount % 2) != 0
-        let positions = self.getDotPositions(isOdd)
-        let borderWidth = self.radius * borderWidthRatio
+        isFull = (inputDotCount == totalDotCount)
+        strokeColor.setStroke()
+        fillColor.setFill()
+        let isOdd = (totalDotCount % 2) != 0
+        let positions = getDotPositions(isOdd)
+        let borderWidth = radius * borderWidthRatio
         for (index, position) in positions.enumerate() {
-            if index < self.inputDotCount {
+            if index < inputDotCount {
                 let pathToFill = UIBezierPath.circlePathWithCenter(position, radius: (radius + borderWidth / 2), lineWidth: borderWidth)
                 pathToFill.fill()
             } else {
@@ -71,12 +68,12 @@ public class PasswordDotView: UIView {
     //MARK: LifeCycle
     public override func awakeFromNib() {
         super.awakeFromNib()
-        self.backgroundColor = UIColor.clearColor()
+        backgroundColor = UIColor.clearColor()
     }
     public override func layoutSubviews() {
         super.layoutSubviews()
-        self.updateRadius()
-        self.setNeedsDisplay()
+        updateRadius()
+        setNeedsDisplay()
     }
     
     //MARK: Animation
@@ -84,8 +81,8 @@ public class PasswordDotView: UIView {
     private var direction = false
     public func shakeAnimationWithCompletion(completion: () -> ()) {
         let maxShakeCount = 5
-        let centerX = CGRectGetMidX(self.bounds)
-        let centerY = CGRectGetMidY(self.bounds)
+        let centerX = CGRectGetMidX(bounds)
+        let centerY = CGRectGetMidY(bounds)
         var duration = 0.10
         var moveX: CGFloat = 5
         
@@ -94,7 +91,7 @@ public class PasswordDotView: UIView {
         } else {
             moveX *= 2
         }
-        self.shakeAnimation(duration, animation: {
+        shakeAnimation(duration, animation: {
             if !self.direction {
                 self.center = CGPoint(x: centerX + moveX, y: centerY)
             } else {
@@ -131,30 +128,30 @@ private extension PasswordDotView {
     
     //MARK: Update Radius
     func updateRadius() {
-        let width = CGRectGetWidth(self.bounds)
-        let height = CGRectGetHeight(self.bounds)
+        let width = CGRectGetWidth(bounds)
+        let height = CGRectGetHeight(bounds)
         var radius = height / 2 - height / 2 * borderWidthRatio
         let spacing = radius * spacingRatio
-        let count = CGFloat(self.totalDotCount)
+        let count = CGFloat(totalDotCount)
         let spaceCount = count - 1
         if (count * radius * 2 + spaceCount * spacing > width) {
             radius = floor((width / (count + spaceCount)) / 2)
         } else {
             radius = floor(height / 2);
         }
-        self.radius = radius - radius * borderWidthRatio
+        radius = radius - radius * borderWidthRatio
     }
 
     //MARK: Dots Layout
     func getDotPositions(isOdd: Bool) -> [CGPoint] {
-        let centerX = CGRectGetMidX(self.bounds)
-        let centerY = CGRectGetMidY(self.bounds)
-        let spacing = self.radius * spacingRatio
-        let middleIndex = isOdd ? (self.totalDotCount + 1) / 2 : (self.totalDotCount) / 2
-        let offSet = isOdd ? 0 : -(self.radius + spacing / 2)
-        let positions: [CGPoint] = (1...self.totalDotCount).map { index in
+        let centerX = CGRectGetMidX(bounds)
+        let centerY = CGRectGetMidY(bounds)
+        let spacing = radius * spacingRatio
+        let middleIndex = isOdd ? (totalDotCount + 1) / 2 : (totalDotCount) / 2
+        let offSet = isOdd ? 0 : -(radius + spacing / 2)
+        let positions: [CGPoint] = (1...totalDotCount).map { index in
             let i = CGFloat(middleIndex - index)
-            let positionX = centerX - (self.radius * 2 + spacing) * i + offSet
+            let positionX = centerX - (radius * 2 + spacing) * i + offSet
             return CGPoint(x: positionX, y: centerY)
         }
         return positions

--- a/SmileLock/Classes/PasswordInputView.swift
+++ b/SmileLock/Classes/PasswordInputView.swift
@@ -23,36 +23,33 @@ public class PasswordInputView: UIView {
     private let fontSizeRatio: CGFloat = 46 / 40
     private let borderWidthRatio: CGFloat = 1 / 26
     private var touchUpFlag = false
-    private var _isAnimating = false
-    public  var isAnimating: Bool {
-        return _isAnimating
-    }
+    private(set) public var isAnimating = false
     
     @IBInspectable
     public var numberString: String = "2" {
         didSet {
-            self.label.text = numberString
+            label.text = numberString
         }
     }
     
     @IBInspectable
     public var borderColor: UIColor = UIColor.darkGrayColor() {
         didSet {
-            self.backgroundColor = borderColor
+            backgroundColor = borderColor
         }
     }
     
     @IBInspectable
     public var circleBackgroundColor: UIColor = UIColor.whiteColor() {
         didSet {
-            self.circleView.backgroundColor = circleBackgroundColor
+            circleView.backgroundColor = circleBackgroundColor
         }
     }
     
     @IBInspectable
     public var textColor: UIColor = UIColor.darkGrayColor() {
         didSet {
-            self.label.textColor = textColor
+            label.textColor = textColor
         }
     }
     
@@ -74,129 +71,129 @@ public class PasswordInputView: UIView {
     //MARK: Life Cycle
     #if TARGET_INTERFACE_BUILDER
     override public func willMoveToSuperview(newSuperview: UIView?) {
-        self.configureSubviews()
+        configureSubviews()
     }
     #else
     override public func awakeFromNib() {
         super.awakeFromNib()
-        self.configureSubviews()
+        configureSubviews()
     }
     #endif
 
     func touchDown() {
         //delegate callback
-        self.delegate?.passwordInputView(self, tappedString: self.numberString)
+        delegate?.passwordInputView(self, tappedString: numberString)
         
         //now touch down, so set touch up flag --> false
-        self.touchUpFlag = false
-        self.touchDownAnimation()
+        touchUpFlag = false
+        touchDownAnimation()
     }
     
     func touchUp() {
         //now touch up, so set touch up flag --> true
-        self.touchUpFlag = true
+        touchUpFlag = true
         
         //only show touch up animation when touch down animation finished        
-        if !self.isAnimating {
-            self.touchUpAnimation()
+        if !isAnimating {
+            touchUpAnimation()
         }
     }
     
     public override func layoutSubviews() {
         super.layoutSubviews()
-        self.updateUI()
+        updateUI()
     }
     
     private func updateUI() {
         //prepare calculate
-        let width = CGRectGetWidth(self.bounds)
-        let height = CGRectGetHeight(self.bounds)
+        let width = CGRectGetWidth(bounds)
+        let height = CGRectGetHeight(bounds)
         let center = CGPoint(x: width/2, y: height/2)
         let radius = min(width, height) / 2
         let borderWidth = radius * borderWidthRatio
         let circleRadius = radius - borderWidth
         
         //update label
-        self.label.text = self.numberString
-        self.label.font = UIFont.systemFontOfSize( radius * fontSizeRatio, weight: UIFontWeightThin)
-        self.label.textColor = self.textColor
+        label.text = numberString
+        label.font = UIFont.systemFontOfSize( radius * fontSizeRatio, weight: UIFontWeightThin)
+        label.textColor = textColor
         
         //update circle view
-        self.circleView.frame = CGRect(x: 0, y: 0, width: 2 * circleRadius, height: 2 * circleRadius)
-        self.circleView.center = center
-        self.circleView.layer.cornerRadius = circleRadius
-        self.circleView.backgroundColor = self.circleBackgroundColor
+        circleView.frame = CGRect(x: 0, y: 0, width: 2 * circleRadius, height: 2 * circleRadius)
+        circleView.center = center
+        circleView.layer.cornerRadius = circleRadius
+        circleView.backgroundColor = circleBackgroundColor
         //circle view border
-        let showBorder = self.circleView.layer.borderWidth > 0
-        self.circleView.layer.borderWidth = showBorder ? borderWidth : 0
+        let showBorder = circleView.layer.borderWidth > 0
+        circleView.layer.borderWidth = showBorder ? borderWidth : 0
         
         //update mask
         let path = UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: 2.0 * CGFloat(M_PI), clockwise: false)
         let maskLayer = CAShapeLayer()
         maskLayer.path = path.CGPath
-        self.layer.mask = maskLayer
+        layer.mask = maskLayer
         
         //update color
-        self.backgroundColor = self.borderColor
+        backgroundColor = borderColor
     }
 }
 
 private extension PasswordInputView {
     //MARK: Awake
     func configureSubviews() {
-        self.addSubview(self.circleView)
+        addSubview(circleView)
 
         //configure label
-        NSLayoutConstraint.addEqualConstraintsFromSubView(self.label, toSuperView: self)
-        self.label.textAlignment = .Center
+        NSLayoutConstraint.addEqualConstraintsFromSubView(label, toSuperView: self)
+        label.textAlignment = .Center
         
         //configure button
-        NSLayoutConstraint.addEqualConstraintsFromSubView(self.button, toSuperView: self)
-        self.button.exclusiveTouch = true
-        self.button.addTarget(self, action: #selector(PasswordInputView.touchDown), forControlEvents: [.TouchDown])
-        self.button.addTarget(self, action: #selector(PasswordInputView.touchUp), forControlEvents: [.TouchUpInside, .TouchDragOutside, .TouchCancel, .TouchDragExit])
+        NSLayoutConstraint.addEqualConstraintsFromSubView(button, toSuperView: self)
+        button.exclusiveTouch = true
+        button.addTarget(self, action: #selector(PasswordInputView.touchDown), forControlEvents: [.TouchDown])
+        button.addTarget(self, action: #selector(PasswordInputView.touchUp), forControlEvents: [.TouchUpInside, .TouchDragOutside, .TouchCancel, .TouchDragExit])
     }
     
     //MARK: Animation
     func touchDownAction() {
-        let originFont = self.label.font
-        self.label.font = UIFont.systemFontOfSize(originFont.pointSize, weight: UIFontWeightLight)
-        self.label.textColor = self.highlightTextColor
-        self.backgroundColor = self.highlightBackgroundColor
-        self.circleView.backgroundColor = self.highlightBackgroundColor
+        let originFont = label.font
+        label.font = UIFont.systemFontOfSize(originFont.pointSize, weight: UIFontWeightLight)
+        label.textColor = highlightTextColor
+        backgroundColor = highlightBackgroundColor
+        circleView.backgroundColor = highlightBackgroundColor
     }
     
     func touchUpAction() {
-        let originFont = self.label.font
-        self.label.font = UIFont.systemFontOfSize(originFont.pointSize, weight: UIFontWeightThin)
-        self.label.textColor = self.textColor
-        self.backgroundColor = self.borderColor
-        self.circleView.backgroundColor = self.circleBackgroundColor
+        let originFont = label.font
+        label.font = UIFont.systemFontOfSize(originFont.pointSize, weight: UIFontWeightThin)
+        label.textColor = textColor
+        backgroundColor = borderColor
+        circleView.backgroundColor = circleBackgroundColor
     }
     
     func touchDownAnimation() {
-        self._isAnimating = true
-        self.tappedAnimation({
+        isAnimating = true
+        tappedAnimation ({
             self.touchDownAction()
-            }, WithCompletion: {
+            }, withCompletion: {
                 if self.touchUpFlag {
                     self.touchUpAnimation()
                 } else {
-                    self._isAnimating = false
+                    self.isAnimating = false
                 }
         })
     }
     
     func touchUpAnimation() {
-        self._isAnimating = true
-        self.tappedAnimation({
+        isAnimating = true
+        tappedAnimation ({
             self.touchUpAction()
-            }, WithCompletion: {
-                self._isAnimating = false
+            }, withCompletion: {
+                self.isAnimating = false
         })
     }
     
-    func tappedAnimation(animation: () -> (), WithCompletion completion: (() -> ())?) {
+    func tappedAnimation(animation: () -> (), withCompletion completion: (() -> ())?) {
         UIView.animateWithDuration(0.25, delay: 0, options: [.AllowUserInteraction, .BeginFromCurrentState], animations: {
             animation()
             }) { _ in


### PR DESCRIPTION
- changed syntax to avoid using `self` when unneeded,
- changed spacing between buttons to keep them pixel perfect (now horizontal and vertical margins are equal),
- fixed typo in `hightlightedColor`