### PR TITLE
Bringing back previous spacing (sorry for the mess)

### DIFF
--- a/SmileLock/Assets/PasswordContainerView.xib
+++ b/SmileLock/Assets/PasswordContainerView.xib
@@ -26,25 +26,25 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="jjW-ce-0kS">
                             <rect key="frame" x="0.0" y="41" width="288" height="370"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="uVh-VM-IQf">
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="uVh-VM-IQf">
                                     <rect key="frame" x="0.0" y="0.0" width="288" height="85"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mNO-I8-8HR" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="86" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="1"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R7E-OV-zzd" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="96" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="101" y="0.0" width="86" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="2"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EWl-Jj-Mvi" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="192" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="202" y="0.0" width="86" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="3"/>
@@ -52,25 +52,25 @@
                                         </view>
                                     </subviews>
                                 </stackView>
-                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="O9w-0G-0IG">
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="O9w-0G-0IG">
                                     <rect key="frame" x="0.0" y="95" width="288" height="85"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t6f-Qj-936" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="86" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="4"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LoJ-Bd-MiK" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="96" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="101" y="0.0" width="86" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="5"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5R9-ep-8IT" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="192" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="202" y="0.0" width="86" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="6"/>
@@ -78,25 +78,25 @@
                                         </view>
                                     </subviews>
                                 </stackView>
-                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="44G-t4-h3e">
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="44G-t4-h3e">
                                     <rect key="frame" x="0.0" y="190" width="288" height="85"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eRG-m3-KYK" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="86" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="7"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nUG-Ev-7sV" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="96" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="101" y="0.0" width="86" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="8"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4fx-v7-wSg" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="192" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="202" y="0.0" width="86" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="9"/>
@@ -104,21 +104,21 @@
                                         </view>
                                     </subviews>
                                 </stackView>
-                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Rfs-SF-Ii0">
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Rfs-SF-Ii0">
                                     <rect key="frame" x="0.0" y="285" width="288" height="85"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZHH-fS-8to">
-                                            <rect key="frame" x="0.0" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="86" height="85"/>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ruX-2t-uDv" customClass="PasswordInputView" customModule="SmileLock" customModuleProvider="target">
-                                            <rect key="frame" x="96" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="101" y="0.0" width="86" height="85"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="numberString" value="0"/>
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="abs-RL-KN4">
-                                            <rect key="frame" x="192" y="0.0" width="96" height="85"/>
+                                            <rect key="frame" x="202" y="0.0" width="86" height="85"/>
                                             <fontDescription key="fontDescription" type="system" weight="light" pointSize="22"/>
                                             <state key="normal" title="Delete">
                                                 <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
Just would like to bring back previous spacing between buttons. Original one (the one before previous PR) looks much better. Really sorry for the mess.

BTW Love this pod :) Could you please update and `trunk push` the `.podspec` after merge? 👍