### PR TITLE
Fix the issue #6, instantiate LAContext again when Touch ID authenticate successfully

### DIFF
--- a/SmileLock-Example/SmileLock-Example.xcodeproj/project.pbxproj
+++ b/SmileLock-Example/SmileLock-Example.xcodeproj/project.pbxproj
@@ -131,9 +131,9 @@
 			children = (
 				B7E3A1AD1CCC6449005F680E /* AppDelegate.swift */,
 				B7E3A1E31CCC68A3005F680E /* extension.swift */,
+				B7E18F271D4A0F3F00A740D4 /* HomeViewController.swift */,
 				B7BAFB401D3B521F009E70FA /* MyPasswordUIValidation.swift */,
 				B7E3A1DF1CCC67A4005F680E /* PasswordLoginViewController.swift */,
-				B7E18F271D4A0F3F00A740D4 /* HomeViewController.swift */,
 				B7A42F861CD2588B00FEB7B0 /* BlurPasswordLoginViewController.swift */,
 				B7E3A1E01CCC67A4005F680E /* PasswordLogin.storyboard */,
 				B7E3A1B41CCC6449005F680E /* Assets.xcassets */,

--- a/SmileLock-Example/SmileLock-Example/HomeViewController.swift
+++ b/SmileLock-Example/SmileLock-Example/HomeViewController.swift
@@ -13,20 +13,11 @@ class HomeViewController: UIViewController {
     //MARK: Property
     let isBlurUI = true
     
-    var isShowed = false
     var loginVCID: String!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.loginVCID = isBlurUI ? "BlurPasswordLoginViewController" : "PasswordLoginViewController"
-    }
-    
-    override func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
-        if !isShowed {
-            self.isShowed = true
-            self.present(self.loginVCID)
-        }
     }
     
     @IBAction func presentLoginVC(sender: AnyObject) {
@@ -36,7 +27,7 @@ class HomeViewController: UIViewController {
     func present(id: String) {
         let loginVC = self.storyboard?.instantiateViewControllerWithIdentifier(id)
         loginVC?.modalTransitionStyle = .CrossDissolve
+        loginVC?.modalPresentationStyle = .OverCurrentContext
         self.presentViewController(loginVC!, animated: true, completion: nil)
     }
-
 }

--- a/SmileLock-Example/SmileLock-Example/MyPasswordUIValidation.swift
+++ b/SmileLock-Example/SmileLock-Example/MyPasswordUIValidation.swift
@@ -24,12 +24,12 @@ class MyPasswordUIValidation: PasswordUIValidation<MyPasswordModel> {
         }
     }
     //handle Touch ID
-    override func touchAuthenticationComplete(passwordContainerView: PasswordContainerView, success: Bool) {
+    override func touchAuthenticationComplete(passwordContainerView: PasswordContainerView, success: Bool, error: NSError?) {
         if success {
             let dummyModel = MyPasswordModel()
             self.success?(dummyModel)
         } else {
-            self.failure?()
+            passwordContainerView.clearInput()
         }
     }
 }

--- a/SmileLock-Example/SmileLock-Example/PasswordLogin.storyboard
+++ b/SmileLock-Example/SmileLock-Example/PasswordLogin.storyboard
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="M9T-pA-Bjj">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="16A254g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="M9T-pA-Bjj">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
@@ -19,10 +19,38 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="fish" translatesAutoresizingMaskIntoConstraints="NO" id="mHM-fQ-E23">
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                             </imageView>
+                            <visualEffectView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eOX-mm-vId">
+                                <rect key="frame" x="245" y="278" width="110" height="44"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="Nng-8y-oom">
+                                    <rect key="frame" x="0.0" y="0.0" width="110" height="44"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <visualEffectView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aoP-EI-P0I">
+                                            <rect key="frame" x="-245" y="-278" width="0.0" height="0.0"/>
+                                            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" id="W9w-DA-OMo">
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            </view>
+                                            <vibrancyEffect>
+                                                <blurEffect style="light"/>
+                                            </vibrancyEffect>
+                                        </visualEffectView>
+                                    </subviews>
+                                </view>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="110" id="KCT-OC-qfk"/>
+                                    <constraint firstAttribute="height" constant="44" id="xeo-bc-uPy"/>
+                                </constraints>
+                                <blurEffect style="light"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </visualEffectView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B7b-qI-7hO">
-                                <rect key="frame" x="260" y="285" width="79" height="30"/>
+                                <rect key="frame" x="245" y="278" width="110" height="44"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                <state key="normal" title="Show Lock">
+                                <state key="normal" title="Show LockUI">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <connections>
@@ -33,11 +61,15 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="GUc-3J-RKn" firstAttribute="top" secondItem="mHM-fQ-E23" secondAttribute="bottom" id="6kj-M9-nVS"/>
-                            <constraint firstItem="B7b-qI-7hO" firstAttribute="centerX" secondItem="fgw-9g-gwd" secondAttribute="centerX" id="8XV-ub-Osi"/>
-                            <constraint firstItem="B7b-qI-7hO" firstAttribute="centerY" secondItem="fgw-9g-gwd" secondAttribute="centerY" id="HwR-V8-tbQ"/>
+                            <constraint firstItem="B7b-qI-7hO" firstAttribute="height" secondItem="eOX-mm-vId" secondAttribute="height" id="Eo7-9y-1v4"/>
+                            <constraint firstItem="eOX-mm-vId" firstAttribute="centerX" secondItem="fgw-9g-gwd" secondAttribute="centerX" id="G4R-Ft-voK"/>
+                            <constraint firstItem="B7b-qI-7hO" firstAttribute="centerY" secondItem="fgw-9g-gwd" secondAttribute="centerY" id="OcE-rz-UPN"/>
                             <constraint firstItem="mHM-fQ-E23" firstAttribute="leading" secondItem="fgw-9g-gwd" secondAttribute="leading" id="YPN-ox-sbw"/>
                             <constraint firstAttribute="trailing" secondItem="mHM-fQ-E23" secondAttribute="trailing" id="ZVW-96-AQM"/>
+                            <constraint firstItem="eOX-mm-vId" firstAttribute="centerY" secondItem="fgw-9g-gwd" secondAttribute="centerY" id="ch5-DU-Qyz"/>
+                            <constraint firstItem="eOX-mm-vId" firstAttribute="width" secondItem="B7b-qI-7hO" secondAttribute="width" id="gDT-Nh-Jby"/>
                             <constraint firstItem="mHM-fQ-E23" firstAttribute="top" secondItem="fgw-9g-gwd" secondAttribute="top" id="hnp-hh-mX4"/>
+                            <constraint firstItem="B7b-qI-7hO" firstAttribute="centerX" secondItem="fgw-9g-gwd" secondAttribute="centerX" id="sHs-zZ-Ypt"/>
                         </constraints>
                     </view>
                 </viewController>
@@ -57,16 +89,16 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="900"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" alignment="center" spacing="26" translatesAutoresizingMaskIntoConstraints="NO" id="eGM-tu-vbC">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="26" translatesAutoresizingMaskIntoConstraints="NO" id="eGM-tu-vbC">
                                 <rect key="frame" x="178" y="427" width="244" height="46"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="ekh-Db-IUo">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="ekh-Db-IUo">
                                         <rect key="frame" x="0.0" y="0.0" width="244" height="46"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="IK8-YT-FI2">
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="IK8-YT-FI2">
                                                 <rect key="frame" x="0.0" y="0.0" width="244" height="46"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Enter Password" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="h4e-n0-DYq">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter Password" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="h4e-n0-DYq">
                                                         <rect key="frame" x="0.0" y="0.0" width="244" height="46"/>
                                                         <fontDescription key="fontDescription" type="system" weight="thin" pointSize="38"/>
                                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
@@ -95,7 +127,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="61N-vg-HIo" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="196" y="360"/>
+            <point key="canvasLocation" x="196" y="334"/>
         </scene>
         <!--Blur Password Login View Controller-->
         <scene sceneID="hf7-qn-5rZ">
@@ -109,9 +141,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="900"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="fish" translatesAutoresizingMaskIntoConstraints="NO" id="LdH-R4-fl7">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="900"/>
-                            </imageView>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F7e-cU-I9V">
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="900"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="B8D-Mm-Ebn">
@@ -124,16 +153,16 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="600" height="900"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" alignment="center" spacing="26" translatesAutoresizingMaskIntoConstraints="NO" id="Ev8-xF-ent">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="26" translatesAutoresizingMaskIntoConstraints="NO" id="Ev8-xF-ent">
                                                         <rect key="frame" x="178" y="427" width="244" height="46"/>
                                                         <subviews>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="LLF-Ta-92n">
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="LLF-Ta-92n">
                                                                 <rect key="frame" x="0.0" y="0.0" width="244" height="46"/>
                                                                 <subviews>
-                                                                    <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="jRX-mN-9Gp">
+                                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="jRX-mN-9Gp">
                                                                         <rect key="frame" x="0.0" y="0.0" width="244" height="46"/>
                                                                         <subviews>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Enter Password" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0TM-Ek-dnq">
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter Password" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="0TM-Ek-dnq">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="244" height="46"/>
                                                                                 <fontDescription key="fontDescription" type="system" weight="thin" pointSize="38"/>
                                                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
@@ -168,16 +197,12 @@
                                 <blurEffect style="dark"/>
                             </visualEffectView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="F7e-cU-I9V" firstAttribute="leading" secondItem="viu-Sf-YQU" secondAttribute="leading" id="P4E-Ia-Sca"/>
-                            <constraint firstItem="3oO-rr-SgG" firstAttribute="top" secondItem="LdH-R4-fl7" secondAttribute="bottom" id="QGG-3K-aW6"/>
-                            <constraint firstAttribute="trailing" secondItem="LdH-R4-fl7" secondAttribute="trailing" id="loF-5X-tuF"/>
                             <constraint firstItem="F7e-cU-I9V" firstAttribute="top" secondItem="viu-Sf-YQU" secondAttribute="top" id="nW3-xj-EIZ"/>
                             <constraint firstAttribute="trailing" secondItem="F7e-cU-I9V" secondAttribute="trailing" id="w6r-Y1-QBQ"/>
-                            <constraint firstItem="LdH-R4-fl7" firstAttribute="top" secondItem="viu-Sf-YQU" secondAttribute="top" id="w7t-tj-hio"/>
                             <constraint firstItem="3oO-rr-SgG" firstAttribute="top" secondItem="F7e-cU-I9V" secondAttribute="bottom" id="yef-qB-1ac"/>
-                            <constraint firstItem="LdH-R4-fl7" firstAttribute="leading" secondItem="viu-Sf-YQU" secondAttribute="leading" id="zzX-yy-s9x"/>
                         </constraints>
                     </view>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
@@ -188,7 +213,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cGw-as-ZSK" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="196" y="-704"/>
+            <point key="canvasLocation" x="196" y="-642"/>
         </scene>
     </scenes>
     <resources>

--- a/SmileLock-Example/SmileLock-Example/PasswordLoginViewController.swift
+++ b/SmileLock-Example/SmileLock-Example/PasswordLoginViewController.swift
@@ -39,11 +39,11 @@ extension PasswordLoginViewController: PasswordInputCompleteProtocol {
         }
     }
     
-    func touchAuthenticationComplete(passwordContainerView: PasswordContainerView, success: Bool) {
+    func touchAuthenticationComplete(passwordContainerView: PasswordContainerView, success: Bool, error: NSError?) {
         if success {
             self.validationSuccess()
         } else {
-            self.validationFail()
+            passwordContainerView.clearInput()
         }
     }
 }

--- a/SmileLock.podspec
+++ b/SmileLock.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SmileLock"
-  s.version      = "1.2.0"
+  s.version      = "1.2.1"
   s.summary      = "A library for make a beautiful Passcode Lock View."
   s.description  = <<-DESC
                    1. Create a beautiful passcode lock view simply.

--- a/SmileLock/Classes/PasswordUIValidation.swift
+++ b/SmileLock/Classes/PasswordUIValidation.swift
@@ -38,5 +38,5 @@ public class PasswordUIValidation<T>: PasswordInputCompleteProtocol {
         success?(model)
     }
     
-    public func touchAuthenticationComplete(passwordContainerView: PasswordContainerView, success: Bool) {}
+    public func touchAuthenticationComplete(passwordContainerView: PasswordContainerView, success: Bool, error: NSError?) {}
 }


### PR DESCRIPTION
As the issue #6 mentioned.

```swift
@IBAction func touchAuthenticationAction(sender: UIButton) {
        guard isTouchAuthenticationAvailable else { return }
        touchIDContext.evaluatePolicy(.DeviceOwnerAuthenticationWithBiometrics, localizedReason: touchAuthenticationReason) { (success, error) in
            dispatch_async(dispatch_get_main_queue(), {
                if success {
                    self.passwordDotView.inputDotCount = self.passwordDotView.totalDotCount
                    // instantiate LAContext again for avoiding the situation that PasswordContainerView stay in memory when authenticate successfully
                    self.touchIDContext = LAContext()
                }
                self.delegate?.touchAuthenticationComplete(self, success: success, error: error)
            })
        }
    }
```