### PR TITLE
Updated Swift 4.2 obsolete class names 

### DIFF
--- a/SmileLock/Classes/PasswordContainerView.swift
+++ b/SmileLock/Classes/PasswordContainerView.swift
@@ -52,7 +52,7 @@ open class PasswordContainerView: UIView {
     open override var tintColor: UIColor! {
         didSet {
             guard !isVibrancyEffect else { return }
-            deleteButton.setTitleColor(tintColor, for: UIControl.State())
+            deleteButton.setTitleColor(tintColor, for: .normal)
             passwordDotView.strokeColor = tintColor
             touchAuthenticationButton.tintColor = tintColor
             passwordInputViews.forEach {
@@ -151,7 +151,7 @@ open class PasswordContainerView: UIView {
             }
         }
         
-        touchAuthenticationButton.setImage(image, for: UIControl.State())
+        touchAuthenticationButton.setImage(image, for: .normal)
         touchAuthenticationButton.tintColor = tintColor
     }
     

--- a/SmileLock/Classes/PasswordContainerView.swift
+++ b/SmileLock/Classes/PasswordContainerView.swift
@@ -52,7 +52,7 @@ open class PasswordContainerView: UIView {
     open override var tintColor: UIColor! {
         didSet {
             guard !isVibrancyEffect else { return }
-            deleteButton.setTitleColor(tintColor, for: UIControlState())
+            deleteButton.setTitleColor(tintColor, for: UIControl.State())
             passwordDotView.strokeColor = tintColor
             touchAuthenticationButton.tintColor = tintColor
             passwordInputViews.forEach {
@@ -151,7 +151,7 @@ open class PasswordContainerView: UIView {
             }
         }
         
-        touchAuthenticationButton.setImage(image, for: UIControlState())
+        touchAuthenticationButton.setImage(image, for: UIControl.State())
         touchAuthenticationButton.tintColor = tintColor
     }
     

--- a/SmileLock/Classes/PasswordDotView.swift
+++ b/SmileLock/Classes/PasswordDotView.swift
@@ -119,7 +119,7 @@ open class PasswordDotView: UIView {
 private extension PasswordDotView {
     //MARK: Animation
     func shakeAnimation(withDuration duration: TimeInterval, animations: @escaping () -> (), completion: @escaping () -> ()) {
-        UIView.animate(withDuration: duration, delay: 0, usingSpringWithDamping: 0.01, initialSpringVelocity: 0.35, options: UIViewAnimationOptions(), animations: {
+        UIView.animate(withDuration: duration, delay: 0, usingSpringWithDamping: 0.01, initialSpringVelocity: 0.35, options: UIView.AnimationOptions(), animations: {
             animations()
         }) { _ in
             completion()


### PR DESCRIPTION
Updated UIControlState() to UIControl.State() and UIViewAnimationOptions() to UIView.AnimationOptions()

For now, it only works in XCode beta3 due to the zero property on UIEdgeInsets error. 

https://download.developer.apple.com/Developer_Tools/Xcode_10_beta_3/Release_Notes_for_Xcode_10_beta_3.pdf

There is also a workaround as per SO answer:

https://stackoverflow.com/questions/50704200/fatal-error-encountered-while-deserializing-sil-global-uiedgeinsetszero